### PR TITLE
Fix tests on Windows.

### DIFF
--- a/t/03-write.t
+++ b/t/03-write.t
@@ -15,6 +15,7 @@ throws-like
 my $fileout = $path ~ 'test1.tar.gz';
 $fileout.IO.unlink if $fileout.IO.e;
 lives-ok { $a.open: $fileout, format => 'gnutar', filters => ['gzip'] }, 'Open file succeedes';
+$a.close;
 $fileout.IO.unlink;
 my Archive::Libarchive $aa .= new:
   operation => LibarchiveWrite,
@@ -22,6 +23,7 @@ my Archive::Libarchive $aa .= new:
   format => 'gnutar',
   filters => ['gzip'];
 is $aa.WHAT, Archive::Libarchive, 'Create object and file for writing';
+$aa.close;
 my Archive::Libarchive $ao .= new:
   operation => LibarchiveOverwrite,
   file => $fileout,


### PR DESCRIPTION
On Windows, unlinking a file that is still open is not allowed. Add
some `.close` calls in order that the archive file is not open prior
to unlinking. With this change, the module fully passes its tests on
Windows.