### PR TITLE
Fix "Native call expected argument 2 to reference a native integer"

### DIFF
--- a/lib/Archive/Libarchive.rakumod
+++ b/lib/Archive/Libarchive.rakumod
@@ -455,7 +455,7 @@ method !copy-data(--> Bool)
 {
   my $res;
   my $buff = Pointer[void].new;
-  my int64 $size;
+  my size_t $size;
   my int64 $offset;
   loop {
     $res = archive_read_data_block $!archive, $buff, $size, $offset;
@@ -478,7 +478,7 @@ method read-file-content(Archive::Libarchive::Entry $e! --> Buf)
     my Buf $buf;
     my $res;
     my $data = Pointer[void].new;
-    my int64 $size;
+    my size_t $size;
     my int64 $offset;
     loop {
       $res = archive_read_data_block $!archive, $data, $size, $offset;


### PR DESCRIPTION
The $size argument of archive_read_data_block is defined as size_t which is an
unsigned integer, so that's what we need to pass. Actually NativeCall exports a
size_t type that we can use directly. Required for the next Rakudo release.